### PR TITLE
fix: getUserLists sort default value

### DIFF
--- a/common/modules/anilist.js
+++ b/common/modules/anilist.js
@@ -419,10 +419,9 @@ class AnilistClient {
   /** @returns {Promise<import('./al.d.ts').Query<{ MediaListCollection: import('./al.d.ts').MediaListCollection }>>} */
   async getUserLists(variables = {}, ignoreExpiry) {
     debug('Getting user lists')
-    variables.id = !variables.userID ? this.userID?.viewer?.data?.Viewer.id : variables.userID
-    variables.sort = variables.sort || 'UPDATED_TIME_DESC'
-    const userSort = variables.sort
-    if (Helper.isUserSort(variables)) variables.sort = 'UPDATED_TIME_DESC'
+    variables.id = variables.userID || this.userID?.viewer?.data?.Viewer.id
+    const userSort = variables.sort || 'UPDATED_TIME_DESC'
+    if (!variables.sort || Helper.isUserSort(variables)) variables.sort = 'UPDATED_TIME_DESC'
     const cachedEntry = this.sortListEntries(userSort, await cache.cachedEntry(caches.USER_LISTS, JSON.stringify(variables), ignoreExpiry))
     if (cachedEntry) return cachedEntry
     const query = /* js */` 

--- a/common/modules/anilist.js
+++ b/common/modules/anilist.js
@@ -420,7 +420,8 @@ class AnilistClient {
   async getUserLists(variables = {}, ignoreExpiry) {
     debug('Getting user lists')
     variables.id = !variables.userID ? this.userID?.viewer?.data?.Viewer.id : variables.userID
-    const userSort = variables.sort || 'UPDATED_TIME_DESC'
+    variables.sort = variables.sort || 'UPDATED_TIME_DESC'
+    const userSort = variables.sort
     if (Helper.isUserSort(variables)) variables.sort = 'UPDATED_TIME_DESC'
     const cachedEntry = this.sortListEntries(userSort, await cache.cachedEntry(caches.USER_LISTS, JSON.stringify(variables), ignoreExpiry))
     if (cachedEntry) return cachedEntry


### PR DESCRIPTION
When `variables.sort` is not defined when calling `getUserLists`, the default value of `alRequest` will be used: `TRENDING_DESC`.
This value cannot be used for this GraphQL query and results in a 400 error.
It happens when the user has chosen to sync AniList (`getUserLists` called from `updateEntry` for instance when the user has watched an episode).

This fix always set a default value (`UPDATED_TIME_DESC`).