### PR TITLE
fix: better audio labels in EpisodeList

### DIFF
--- a/common/components/SidebarLink.svelte
+++ b/common/components/SidebarLink.svelte
@@ -24,7 +24,7 @@
   <span class='text-nowrap d-flex align-items-center w-full h-full'>
     {#if image}
       <span class='rounded d-flex'>
-        <img src={image} class='h-30 rounded' style='height: {btnSize} !important; width: {btnSize} !important' alt='logo' />
+        <img src={image} class='h-30 w-30 rounded' style='height: {btnSize} !important; width: {btnSize} !important' alt='logo' />
       </span>
       <span class='text ml-20' class:font-weight-bolder={overlay === 'profile'} class:font-size-16={overlay === 'profile'}>{text}</span>
     {:else}

--- a/common/css.css
+++ b/common/css.css
@@ -68,11 +68,6 @@
   background-color: var(--dark-color) !important;
 }
 
-.h-30 {
-  width: 3rem;
-  height: 3rem;
-}
-
 @media (min-width: 769px) {
   :root {
     --sidebar-minimised: 7rem;
@@ -143,8 +138,37 @@ a[href]:active, button:not([disabled]):active, fieldset:not([disabled]):active, 
 .h-10 {
   height: 1rem !important;
 }
+.h-20 {
+  height: 2rem !important;
+}
 .h-25 {
   height: 2.5rem !important;
+}
+.h-30 {
+  height: 3rem !important;
+}
+
+.w-10 {
+  width: 1rem !important;
+}
+.w-20 {
+  width: 2rem !important;
+}
+.w-25 {
+  width: 2.5rem !important;
+}
+.w-30 {
+  width: 3rem !important;
+}
+
+.ml-2 {
+  margin-left: 0.2rem;
+}
+.ml-3 {
+  margin-left: 0.3rem;
+}
+.ml-4 {
+  margin-left: 0.4rem;
 }
 
 body {
@@ -310,4 +334,61 @@ img[src=''], img[src=' '] {
     padding-left: 5rem !important;
     padding-right: 5rem !important;
   }
+}
+
+.gap-0 {
+  gap: 0 !important;
+}
+.gap-1 {
+  gap: 0.25rem !important;
+}
+.gap-2 {
+  gap: 0.5rem !important;
+}
+.gap-3 {
+  gap: 1rem !important;
+}
+.gap-4 {
+  gap: 1.5rem !important;
+}
+.gap-5 {
+  gap: 3rem !important;
+}
+
+.row-gap-0 {
+  gap: 0 !important;
+}
+.row-gap-1 {
+  row-gap: 0.25rem !important;
+}
+.row-gap-2 {
+  row-gap: 0.5rem !important;
+}
+.row-gap-3 {
+  row-gap: 1rem !important;
+}
+.row-gap-4 {
+  row-gap: 1.5rem !important;
+}
+.row-gap-5 {
+  row-gap: 3rem !important;
+}
+
+.column-gap-0 {
+  column-gap: 0 !important;
+}
+.column-gap-1 {
+  column-gap: 0.25rem !important;
+}
+.column-gap-2 {
+  column-gap: 0.5rem !important;
+}
+.column-gap-3 {
+  column-gap: 1rem !important;
+}
+.column-gap-4 {
+  column-gap: 1.5rem !important;
+}
+.column-gap-5 {
+  column-gap: 3rem !important;
 }

--- a/common/views/Settings/Settings.svelte
+++ b/common/views/Settings/Settings.svelte
@@ -105,7 +105,7 @@
         <div class='px-20 py-10 d-flex align-items-center'>
           {#if Helper.getUser()}
             <span class='rounded mr-10'>
-              <img src={Helper.getUserAvatar()} class='h-30 rounded' alt='logo' />
+              <img src={Helper.getUserAvatar()} class='h-30 w-30 rounded' alt='logo' />
             </span>
             <div class='font-size-16 login-image-text'>Profiles</div>
           {:else}

--- a/common/views/ViewAnime/EpisodeList.svelte
+++ b/common/views/ViewAnime/EpisodeList.svelte
@@ -2,8 +2,12 @@
   import { animeSchedule } from '@/modules/animeschedule.js'
   import { malDubs } from '@/modules/animedubs.js'
   import { past } from '@/modules/util.js'
+  import { settings } from '@/modules/settings.js'
+  import { Mic, Captions } from 'lucide-svelte'
 
   async function dubbedEpisode(i, media) {
+    if (!settings.value.cardAudio) return
+
     const episode = i + 1
     const entry = (await animeSchedule.dubAiringLists.value)?.find(entry => entry.media?.media?.id === media.id)
     const episodeEntry = (await animeSchedule.dubAiredLists.value)?.find(entry => entry?.id === media.id && entry?.episode?.aired === episode)
@@ -265,7 +269,7 @@
                 </div>
               {/if}
               <div class='h-full w-full px-20 pt-15 d-flex flex-column'>
-                <div class='w-full d-flex flex-row mb-15'>
+                <div class='w-full d-flex flex-row mb-5'>
                   <div class='text-white font-weight-bold font-size-16 overflow-hidden title'>
                     {#if resolvedTitle && !resolvedTitle.includes(episode)}{episode}. {/if}{resolvedTitle || 'Episode ' + episode}
                   </div>
@@ -276,26 +280,28 @@
                   {/if}
                 </div>
                 {#if completed}
-                  <div class='progress mb-15' style='height: 2px; min-height: 2px;'>
+                  <div class='progress mb-5' style='height: 2px; min-height: 2px;'>
                     <div class='progress-bar w-full'/>
                   </div>
                 {:else if progress}
-                  <div class='progress mb-15' style='height: 2px; min-height: 2px;'>
+                  <div class='progress mb-5' style='height: 2px; min-height: 2px;'>
                     <div class='progress-bar' style='width: {progress}%'/>
                   </div>
                 {/if}
                 <div class='font-size-12 overflow-hidden'>
                   {summary || ''}
                 </div>
-                <div class='font-size-12 mt-auto' class:pt-10={dubAiring} class:pt-15={!dubAiring} class:mb-5={dubAiring} class:mb-10={!dubAiring}>
+                <div class='font-size-12 mt-auto mb-5 pt-10'>
                   {#if dubAiring}
-                    <div class='d-flex flex-row date-row'>
-                      <div class='py-5 px-10 text-dark text-nowrap rounded-top rounded-left font-weight-bold' class:bg-danger={dubAiring.delayed} class:bg-dubbed={!dubAiring.delayed}>
-                        Dub: {dubAiring.text}
+                    <div class='d-flex flex-row flex-wrap justify-content-start gap-2'>
+                      <div class='py-1 px-5 h-20 text-dark text-nowrap rounded font-weight-bold align-items-center d-inline-flex align-self-center' class:bg-danger={dubAiring.delayed} class:bg-dubbed={!dubAiring.delayed}>
+                        <Mic size='1.8rem' strokeWidth='2' />
+                        <span class='ml-4'>{dubAiring.text}</span>
                       </div>
                       {#if airdate || dubAiring.delayed}
-                        <div class='ml-5 py-5 px-10 text-dark text-nowrap rounded-top rounded-left font-weight-bold' class:bg-danger={!airdate && dubAiring.delayed} class:bg-subbed={!(!airdate && dubAiring.delayed)}>
-                          Sub: {airdate ? since(new Date(airdate)) : dubAiring.text}
+                        <div class='py-1 px-5 h-20 text-dark text-nowrap rounded font-weight-bold align-items-center d-inline-flex align-self-center' class:bg-danger={!airdate && dubAiring.delayed} class:bg-subbed={!(!airdate && dubAiring.delayed)}>
+                          <Captions size='2rem' strokeWidth='1.5' />
+                          <span class='ml-2'>{airdate ? since(new Date(airdate)) : dubAiring.text}</span>
                         </div>
                       {/if}
                     </div>
@@ -343,9 +349,6 @@
     }
     .scale {
       height: auto !important;
-    }
-    .date-row {
-      justify-content: center !important;
     }
     img {
       width: 100%;


### PR DESCRIPTION
This PR improves the rendering of audio labels in `EpisodeList`:

Before:
![image](https://github.com/user-attachments/assets/f58fe03a-cd1c-4c0c-86ad-855b2bf1faa4)

As you can see there are a lot of issues:
- The title is too long.
- The duration cannot be seen.
- The audio labels are cropped.

After:
![image](https://github.com/user-attachments/assets/0083022f-0677-4dbc-8579-9a36724331b1)

The following changes have been made:
- Overflows are correctly handled.
- Labels are smaller.
- If there is no place to show both labels inline, they wrap.
- Use icons instead of text to be uniform.
- If the user has unselected the "Card Audio" setting, the labels are not shown.

Also some changes to improve the global CSS file (add gap utilities, improve sizing utilities).