### PR TITLE
Enable webSecurity

### DIFF
--- a/electron/src/main/app.js
+++ b/electron/src/main/app.js
@@ -44,7 +44,7 @@ export default class App {
     backgroundColor: '#17191c',
     autoHideMenuBar: true,
     webPreferences: {
-      webSecurity: false,
+      webSecurity: true,
       allowRunningInsecureContent: false,
       enableBlinkFeatures: 'FontAccess, AudioVideoTracks',
       backgroundThrottling: false,
@@ -272,7 +272,7 @@ export default class App {
   makeWebTorrentWindow() {
     return new BrowserWindow({
       webPreferences: {
-        webSecurity: false,
+        webSecurity: true,
         allowRunningInsecureContent: false,
         nodeIntegration: true,
         contextIsolation: false,


### PR DESCRIPTION
## Description

Enables webSecurity in the electron app. 

## Type of Change

- [x] 🐛 **Fix** — Bug or regression fix (`fix:`)
- [ ] ✨ **Feature** — New feature or enhancement (`feat:`)
- [ ] 🧹 **Chore** — Build, CI, or tooling update (`chore:`)
- [ ] 🧠 **Refactor** — Code improvement without functional change (`refactor:`)
- [ ] 🧾 **Docs** — Documentation only (`docs:`)
- [ ] ⚙️ **Other** — Please explain below

## Platforms Affected

<!-- Mark all platforms this change affects -->

- [x] 🪟 **Windows**
- [x] 🐧 **Linux**
- [x] 🍎 **macOS**
- [ ] 📱 **Android**

## Testing

- [x] Verified on Linux
- [x] No adverse effects observed after using this patch for over a month

### Test Configuration:
- **OS:** NixOS Unstable, Linux 6.19.0
- **Architecture:** x64
- **App Version:** 6.5.0


### Steps to Test:
1. Apply the patch
2. Use the app for a while
3. Observe no difference in UX

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)

## Additional Notes

Was originally brought up while packaging Shiru [for nixpkgs](https://github.com/NixOS/nixpkgs/pull/467929#issuecomment-3633580783) and was briefly discussed on Discord.