### PR TITLE
Delay keybinds

### DIFF
--- a/common/routes/player/PlayerPage.svelte
+++ b/common/routes/player/PlayerPage.svelte
@@ -27,7 +27,7 @@
   import 'rvfc-polyfill'
   import { IPC, ELECTRON, ANDROID } from '@/modules/bridge.js'
   import WPC from '@/modules/wpc.js'
-  import { X, Minus, ArrowDown, ArrowUp, Captions, CircleHelp, Contrast, FastForward, Keyboard, EllipsisVertical, SquareArrowOutUpRight, List, Eye, FilePlus2, ListMusic, ListVideo, Maximize, Minimize, Pause, PictureInPicture, PictureInPicture2, Play, Proportions, RefreshCcw, Rewind, RotateCcw, RotateCw, ScreenShare, SkipBack, SkipForward, Users, Volume1, Volume2, VolumeX, SlidersVertical, SquarePen, Milestone } from 'lucide-svelte'
+  import { X, Minus, ArrowDown, ArrowUp, Captions, CircleHelp, Contrast, FastForward, Keyboard, EllipsisVertical, SquareArrowOutUpRight, List, Eye, FilePlus2, ListMusic, ListVideo, Maximize, Minimize, Pause, PictureInPicture, PictureInPicture2, Play, Proportions, RefreshCcw, Rewind, RotateCcw, RotateCw, ScreenShare, SkipBack, SkipForward, Users, Volume1, Volume2, VolumeX, SlidersVertical, SquarePen, Milestone, ClockArrowDown, ClockArrowUp } from 'lucide-svelte'
   import Debug from 'debug'
   const debug = Debug('ui:player')
 
@@ -864,14 +864,14 @@
     Comma: {
       fn: (e) => { if (!viewAnime && document.activeElement?.tagName !== 'INPUT' && document.activeElement?.tagName !== 'TEXTAREA') { subDelay = Number((Number(subDelay) + (e.shiftKey ? -1.0 : -0.1)).toFixed(1)); subDelayText = subDelay > 0 ? `+${subDelay}s` : `${subDelay}s`; subDelayVisible = true; clearTimeout(subDelayTimeout); subDelayTimeout = setTimeout(() => subDelayVisible = false, 600) } },
       id: 'sub_delay_decrease',
-      icon: Captions,
+      icon: ClockArrowDown,
       type: 'icon',
       desc: 'Subtitle Delay -0.1s / -1.0s'
     },
     Period: {
       fn: (e) => { if (!viewAnime && document.activeElement?.tagName !== 'INPUT' && document.activeElement?.tagName !== 'TEXTAREA') { subDelay = Number((Number(subDelay) + (e.shiftKey ? 1.0 : 0.1)).toFixed(1)); subDelayText = subDelay > 0 ? `+${subDelay}s` : `${subDelay}s`; subDelayVisible = true; clearTimeout(subDelayTimeout); subDelayTimeout = setTimeout(() => subDelayVisible = false, 600) } },
       id: 'sub_delay_increase',
-      icon: Captions,
+      icon: ClockArrowUp,
       type: 'icon',
       desc: 'Subtitle Delay +0.1s / +1.0s'
     }


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does and if it fixes anything. Use "Fixes #123" or "Closes #123" to auto-close the issue when merged -->

Delay controls via keybinds

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] 🐛 **Fix** — Bug or regression fix (`fix:`)
- [x] ✨ **Feature** — New feature or enhancement (`feat:`)
- [ ] 🧹 **Chore** — Build, CI, or tooling update (`chore:`)
- [ ] 🧠 **Refactor** — Code improvement without functional change (`refactor:`)
- [ ] 🧾 **Docs** — Documentation only (`docs:`)
- [ ] ⚙️ **Other** — Please explain below


## Platforms Affected

<!-- Mark all platforms this change affects -->

- [x] 🪟 **Windows**
- [x] 🐧 **Linux**
- [x] 🍎 **macOS**
- [ ] 📱 **Android**


## Testing

<!-- Describe how you tested your changes and the environments used.
Example:
- [x] 
- [ ] Tested Android build via Capacitor
- [ ] Confirmed tray icon now persists after wake
-->


### Test Configuration:
- **OS:** Linux 6.18.13-arch1-1
- **Architecture:** x64
- **App Version:** v6.5.0


### Steps to Test:
1. Open anime
2. Press/hold , or . for a 0.1s change, or Shift + , or Shift + . for a 1.0s change



## Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules (if applicable)


## Screenshots/Videos

https://github.com/user-attachments/assets/f7483f47-56ab-42ce-a58d-095839890916

https://github.com/user-attachments/assets/746438bb-c495-4a01-8335-e9955967689e

Videos does not capture popups..

<img width="901" height="335" alt="image" src="https://github.com/user-attachments/assets/242fbbdd-4c03-4ea4-aa66-35bae16f9bf0" />



<!-- If applicable, add screenshots or videos to demonstrate the changes -->


## Additional Notes
>My desired keys would be Z and X, because it’s easier to use Shift + Z/X and I'm used to using ZX for delay control from mpv. 
However, X is already taken for screenshots. Changing the binds from the long-standing defaults would not be user-friendly.

<!-- Any additional information, context, or considerations for reviewers -->

```

Earlier (Speed Up) ← [ Key 1 ]   [ Key 2 ] → Later (Delay)
----------------------------------------------------------
Hayase:               [  ;  ]   [  '  ]
VLC:                  [  G  ]   [  H  ]
mpv:                  [  Z  ]   [  X  ]
PotPlayer:            [  <  ]   [  >  ]
MPC-HC:               [  F1 ]   [  F2 ]
IINA:                 [  Z  ]   [  X  ]
KMPlayer:             [  Shift+F1 ]   [  Shift+F2 ]

```