### PR TITLE
chore: Dont specify flatpak details if not needed

### DIFF
--- a/electron/electron-builder.yml
+++ b/electron/electron-builder.yml
@@ -71,15 +71,8 @@ flatpak:
   description: *description
   desktop:
     entry:
-      Comment: *description
       Keywords: anime
       MimeType: x-scheme-handler/shiru;
-      Icon: shiru
-  files:
-    - - buildResources/icon.png
-      - /share/icons/hicolor/512x512/apps/shiru.png
-    - - buildResources/icon.png
-      - /share/icons/hicolor/256x256/apps/shiru.png
 mac:
   artifactName: ${os}-${productName}-v${version}.${ext}
   singleArchFiles: node_modules/+(register-scheme|utp-native|fs-native-extensions)/**


### PR DESCRIPTION
## Description

This MR removes information that the build system infers automatically from other metadata.
in this case, the `flatpak.desktop.entry.Comment` field is derived from the `flatpak.description` field (verified that is what shown up in the `desktop` file), and the  `flatpak.desktop.entry.Icon` is derived from `linux.icon`.

This also has the effect of fixing an issue where the icon doesn't show up on the desktop, and the generic executable icon is shown instead. it seems that the build system creates an icon for the flatpak as `share/icons/hicolor/512x512/apps/com.github.rockinchaos.shiru.png` anyway, and the additional icons/the name given in `flatpak.desktop.entry.Icon` just break things.

relevant logs from the build system:
```
2026-06-21T20:39:55.234Z @malept/flatpak-bundler 1> Finishing app
2026-06-21T20:39:55.264Z @malept/flatpak-bundler 1> Exporting share/applications/com.github.rockinchaos.shiru.desktop
2026-06-21T20:39:55.266Z @malept/flatpak-bundler 1> Not exporting share/icons/hicolor/256x256/apps/shiru.png, non-allowed export filename
2026-06-21T20:39:55.268Z @malept/flatpak-bundler 1> Not exporting share/icons/hicolor/512x512/apps/shiru.png, non-allowed export filename
Exporting share/icons/hicolor/512x512/apps/com.github.rockinchaos.shiru.png
2026-06-21T20:39:55.272Z @malept/flatpak-bundler 1> Please review the exported files and the metadata
2026-06-21T20:39:55.277Z @malept/flatpak-bundler 1> Committing stage finish to cache
2026-06-21T20:39:57.071Z @malept/flatpak-bundler 1> Pruning cache
2026-06-21T20:39:57.089Z @malept/flatpak-bundler $ flatpak build-export --arch x86_64 /tmp/flatpak-bundler-12-SFhpeQ1M3mVa/repo /tmp/flatpak-bundler-12-SFhpeQ1M3mVa/build stable
2026-06-21T20:39:57.111Z @malept/flatpak-bundler 1> WARNING: Icon not matching app id in /tmp/flatpak-bundler-12-SFhpeQ1M3mVa/build/export/share/applications/com.github.rockinchaos.shiru.desktop: shiru
2026-06-21T20:39:57.111Z @malept/flatpak-bundler 1> WARNING: Icon referenced in desktop file but not exported: shiru
2026-06-21T20:40:09.229Z @malept/flatpak-bundler 1> Commit: 7666bc31fcb173d567a25e7c4cc30deba53eabf9a7012cab40628d9dbdd7b7cb
```

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] 🐛 **Fix** — Bug or regression fix (`fix:`)
- [ ] ✨ **Feature** — New feature or enhancement (`feat:`)
- [x] 🧹 **Chore** — Build, CI, or tooling update (`chore:`)
- [ ] 🧠 **Refactor** — Code improvement without functional change (`refactor:`)
- [ ] 🧾 **Docs** — Documentation only (`docs:`)
- [ ] ⚙️ **Other** — Please explain below


## Platforms Affected

<!-- Mark all platforms this change affects -->

- [ ] 🪟 **Windows**
- [x] 🐧 **Linux**
- [ ] 🍎 **macOS**
- [ ] 📱 **Android**


## Testing

<!-- Describe how you tested your changes and the environments used.
Example:
- [x] Verified on Windows 11
- [x] Tested Android build via Capacitor
- [x] Confirmed tray icon now persists after wake
-->

the flatpak was built using the following dockerfile:
```Dockerfile
FROM fedora:43  AS build

RUN dnf install -y g++ make git unzip pnpm flatpak-builder \
    nspr glib2 nss dbus dbus-glib atk cups-libs cairo gtk3 mesa-libgbm alsa-lib libxcrypt-compat
RUN flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
RUN git config --global --add protocol.file.allow always

COPY --exclude=Dockerfile . /src
WORKDIR /src/electron
RUN pnpm install
RUN env DEBUG="@malept/flatpak-bundler" pnpm build

FROM scratch
COPY --from=build /src/electron/dist/linux-Shiru-* /
```
then flatpak was obtained with
```
podman build --security-opt=seccomp=unconfined --security-opt=label=disable --device /dev/fuse --cap-add=CAP_SYS_ADMIN,CAP_NET_ADMIN --output=$DEST/ .
```

### Test Configuration:
- **OS:** Fedora Silverblue 43 <!-- e.g., Windows 11, macOS Sonoma, Android 14 -->
- **Architecture:** x86_64 <!-- e.g., x64, arm64, arm64-v8a -->
- **App Version:** 6.7.0 <!-- e.g., v6.0.0 -->


### Steps to Test:
1. install flatpak
2. search for app on desktop
3. check if it has the shiru icon.


## Checklist

<!-- Mark completed items with an "x" -->

- [x] My code is my own original work
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)


## Screenshots/Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->


## Additional Notes

<!-- Any additional information, context, or considerations for reviewers -->