### PR TITLE
persist and apply custom CSS on startup

### DIFF
--- a/common/App.svelte
+++ b/common/App.svelte
@@ -21,6 +21,7 @@
   import { status } from '@/modules/networking.js'
   import Toaster from '@/components/toast/Toaster.svelte'
   import { onMount, onDestroy } from 'svelte'
+  import '@/modules/themes.js'
 
   let currentStatus = status.value
   let transitionTimer

--- a/common/main.js
+++ b/common/main.js
@@ -5,6 +5,7 @@ import { SUPPORTS } from '@/modules/support.js'
 import { COMMON } from '@/modules/bridge.js'
 import '@/css.css'
 import '@/themes.css'
+import '@/modules/themes.js'
 import '@/typography.css'
 
 let splash

--- a/common/main.js
+++ b/common/main.js
@@ -5,7 +5,6 @@ import { SUPPORTS } from '@/modules/support.js'
 import { COMMON } from '@/modules/bridge.js'
 import '@/css.css'
 import '@/themes.css'
-import '@/modules/themes.js'
 import '@/typography.css'
 
 let splash

--- a/common/modules/themes.js
+++ b/common/modules/themes.js
@@ -16,7 +16,7 @@ variables.subscribe(value => {
 })
 
 export function setStyle(value) {
-  settings.value.customCSS = value
+  settings.update(s => ({ ...s, customCSS: value ?? s.customCSS }))
   document.documentElement.setAttribute('data-theme', settings.value.presetTheme)
   document.querySelector('meta[name="theme-color"]').setAttribute('content', getComputedStyle(document.documentElement).getPropertyValue('--theme-color').trim())
   style.textContent = `:root[data-theme='${settings.value.presetTheme}']{${(value || variables.value).replace(/{|}/g, '')}}`


### PR DESCRIPTION
# fix: persist and apply custom CSS on startup

## Description

Fixes two bugs with the CSS Variables setting under Settings > Interface.

**Bug 1: CSS not saved on reload**
`setStyle()` in `themes.js` was directly mutating `settings.value.customCSS`, which bypasses the store's subscriber. Since the subscriber is what writes to IndexedDB, the CSS was never actually persisted. Opening the app after a reload would show the textbox empty (or reverting to default).

Fix: use `settings.update()` instead so the subscriber fires and the value gets saved properly.

**Bug 2: Saved CSS not applied on startup**
`themes.js` was only ever imported by `InterfaceTab.svelte`, so the module never ran unless the user opened Settings. Even if CSS was somehow saved, it wouldn't be applied until Settings was visited.

Fix: import `themes.js` in `main.js` so it initialises on every launch and applies saved CSS to the DOM immediately.

**Side note for users:** some base variables like `--dark-color-base-hue` and `--dark-color-base-saturation` are declared with `!important` in the compiled CSS, so overriding those requires `!important` in your custom CSS too. That's existing behaviour, not introduced by this fix.

## Type of Change

- [x] 🐛 **Fix** — Bug or regression fix (`fix:`)

## Platforms Affected

- [x] 🪟 **Windows**
- [x] 🐧 **Linux**
- [x] 🍎 **macOS**
- [x] 📱 **Android**

## Testing

- [x] Verified on Windows 11: custom CSS now persists across restarts and is applied on launch without needing to open Settings

### Test Configuration:
- **OS:** Windows 11
- **Architecture:** x64
- **App Version:** latest

### Steps to Test:
1. Open Settings > Interface, enter some CSS variables (e.g. `--accent-color: #FF0080;`)
2. Restart the app
3. CSS should still be in the textbox and visually applied without opening Settings

## Checklist

- [x] My code is my own original work
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project

## Additional Notes

Tested by patching the installed ASAR and confirming behaviour before fixing at the source level. Both bugs are independent but together they mean the CSS Variables field was essentially non-functional end to end.